### PR TITLE
Check branch coverage, update config-changed handler to not restart if pebble config hasn't changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 build/
 *.charm
+*.swp
 
 .coverage
 **/__pycache__/

--- a/run_tests
+++ b/run_tests
@@ -13,5 +13,5 @@ else
 fi
 
 flake8
-coverage run --source=src -m unittest -v "$@"
+coverage run --branch --source=src -m unittest -v "$@"
 coverage report -m

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,11 +49,9 @@ class HelloKubeconCharm(CharmBase):
         # Create a new config layer
         layer = self._gosherve_layer()
         # Get the current config
-        plan = container.get_plan()
+        services = container.get_plan().to_dict().get("services", [])
         # Check if there are any changes to services
-        if not plan or not plan.services or (
-            plan.services["gosherve"].to_dict() != layer["services"]["gosherve"]
-        ):
+        if not services or (services["gosherve"] != layer["services"]["gosherve"]):
             # Changes were made, add the new layer
             container.add_layer("gosherve", layer, combine=True)
             logging.info("Added updated layer 'gosherve' to Pebble plan")

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,7 @@ class HelloKubeconCharm(CharmBase):
         # Get the current config
         services = container.get_plan().to_dict().get("services", [])
         # Check if there are any changes to services
-        if not services or services != layer["services"]:
+        if services != layer["services"]:
             # Changes were made, add the new layer
             container.add_layer("gosherve", layer, combine=True)
             logging.info("Added updated layer 'gosherve' to Pebble plan")

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,9 @@ class HelloKubeconCharm(CharmBase):
         # Get the current config
         plan = container.get_plan()
         # Check if there are any changes to services
-        if plan.services != layer["services"]:
+        if not plan or not plan.services or (
+            plan.services["gosherve"].to_dict() != layer["services"]["gosherve"]
+        ):
             # Changes were made, add the new layer
             container.add_layer("gosherve", layer, combine=True)
             logging.info("Added updated layer 'gosherve' to Pebble plan")

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,7 @@ class HelloKubeconCharm(CharmBase):
         # Get the current config
         services = container.get_plan().to_dict().get("services", [])
         # Check if there are any changes to services
-        if not services or services["gosherve"] != layer["services"]["gosherve"]:
+        if not services or services != layer["services"]:
             # Changes were made, add the new layer
             container.add_layer("gosherve", layer, combine=True)
             logging.info("Added updated layer 'gosherve' to Pebble plan")

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,7 @@ class HelloKubeconCharm(CharmBase):
         # Get the current config
         services = container.get_plan().to_dict().get("services", [])
         # Check if there are any changes to services
-        if not services or (services["gosherve"] != layer["services"]["gosherve"]):
+        if not services or services["gosherve"] != layer["services"]["gosherve"]:
             # Changes were made, add the new layer
             container.add_layer("gosherve", layer, combine=True)
             logging.info("Added updated layer 'gosherve' to Pebble plan")

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -65,15 +65,7 @@ class TestCharm(unittest.TestCase):
         # Now test again with different config, knowing that the "gosherve"
         # service is running (because we've just tested it above), so we'll
         # be testing the `is_running() == True` codepath.
-        # We also want to confirm logging here, because later on we're using
-        # lack of logging to confirm different behaviour.
-        with self.assertLogs(level='INFO') as logger:
-            self.harness.update_config({"redirect-map": "test2 value"})
-        expected_logs = [
-            "INFO:root:Added updated layer 'gosherve' to Pebble plan",
-            "INFO:root:Restarted gosherve service",
-        ]
-        self.assertEqual(sorted(logger.output), expected_logs)
+        self.harness.update_config({"redirect-map": "test2 value"})
         plan = self.harness.get_container_pebble_plan("gosherve")
         # Adjust the expected plan
         expected["services"]["gosherve"]["environment"]["REDIRECT_MAP_URL"] = "test2 value"
@@ -83,12 +75,12 @@ class TestCharm(unittest.TestCase):
 
         # And finally test again with the same config to ensure we exercise
         # the case where the plan we've created matches the active one. We're
-        # asserting that we raise an error here because there are no logs of
-        # level INFO or higher. This is a proxy for confirming we're not adding
-        # a pebble layer or restarting the service, as we log those things.
-        with self.assertRaises(AssertionError):
-            with self.assertLogs(level='INFO'):
-                self.harness.charm.on.config_changed.emit()
+        # going to mock the container.stop and container.start calls to confirm
+        # they were called appropriately.
+        with patch('ops.model.Container.start') as _start, patch('ops.model.Container.stop') as _stop:
+            self.harness.charm.on.config_changed.emit()
+            _start.assert_not_called()
+            _stop.assert_not_called()
 
     @patch("charm.HelloKubeconCharm._fetch_site")
     def test_on_install(self, _fetch_site):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -76,7 +76,7 @@ class TestCharm(unittest.TestCase):
         # And finally test again with the same config to ensure we exercise
         # the case where the plan we've created matches the active one. We're
         # going to mock the container.stop and container.start calls to confirm
-        # they were called appropriately.
+        # they were not called.
         with patch('ops.model.Container.start') as _start, patch('ops.model.Container.stop') as _stop:
             self.harness.charm.on.config_changed.emit()
             _start.assert_not_called()


### PR DESCRIPTION
Add branch coverage so that we're testing both code paths of an `if` statement, for example.

Update the config-changed handler so it's correctly recognising when our pebble layer config hasn't changed and test that we're not restarting pebble (indirectly, by testing log output) in that case.