### PR TITLE
Remove references to ingress-class, ingress charm chooses this automatically now

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ $ juju deploy hello-kubecon
 $ juju deploy nginx-ingress-integrator
 # Relate our app to the ingress
 $ juju relate hello-kubecon nginx-ingress-integrator
-# Set the ingress class
-$ juju config nginx-ingress-integrator ingress-class="public"
 # Add an entry to /etc/hosts
 $ echo "127.0.1.1 hellokubecon.juju" | sudo tee -a /etc/hosts
 # Wait for the deployment to complete
@@ -121,8 +119,6 @@ $ juju deploy ./hello-kubecon.charm --resource gosherve-image=jnsgruk/gosherve:l
 $ juju deploy nginx-ingress-integrator
 # Relate our app to the ingress
 $ juju relate hello-kubecon nginx-ingress-integrator
-# Set the ingress class
-$ juju config nginx-ingress-integrator ingress-class="public"
 # Add an entry to /etc/hosts
 $ echo "127.0.1.1 hellokubecon.juju" | sudo tee -a /etc/hosts
 # Wait for the deployment to complete


### PR DESCRIPTION
See https://git.launchpad.net/charm-k8s-ingress/commit/?id=741fbddbb6e3faf039d3cb5827cd517a7413cdcf for details, this is now looked up automatically so in the simple deployment case (on MicroK8s with the ingress add-on enabled) this isn't needed.