### PR TITLE
Use a default hostname of the deployed application name, per current guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ juju deploy nginx-ingress-integrator
 # Relate our app to the ingress
 $ juju relate hello-kubecon nginx-ingress-integrator
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 hellokubecon.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 hello-kubecon" | sudo tee -a /etc/hosts
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
 ```
@@ -120,7 +120,7 @@ $ juju deploy nginx-ingress-integrator
 # Relate our app to the ingress
 $ juju relate hello-kubecon nginx-ingress-integrator
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 hellokubecon.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 hello-kubecon" | sudo tee -a /etc/hosts
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,11 @@
 # Learn more about config at: https://juju.is/docs/sdk/config
 
 options:
+  external-hostname:
+    default: ""
+    description: >
+      The external hostname this application should be available on. If unset,
+      it will default to the deployed application name in the model.
   redirect-map:
     default: "https://jnsgr.uk/demo-routes"
     description: A URL pointing to a list of redirects for Gosherve.

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ options:
     description: >
       The external hostname this application should be available on. If unset,
       it will default to the deployed application name in the model.
+    type: string
   redirect-map:
     default: "https://jnsgr.uk/demo-routes"
     description: A URL pointing to a list of redirects for Gosherve.

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,7 +33,7 @@ class HelloKubeconCharm(CharmBase):
         self.framework.observe(self.on.pull_site_action, self._pull_site_action)
 
         self.ingress = IngressRequires(self, {
-            "service-hostname": "hellokubecon.juju",
+            "service-hostname": self.app.name,
             "service-name": self.app.name,
             "service-port": 8080
         })

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,10 +33,18 @@ class HelloKubeconCharm(CharmBase):
         self.framework.observe(self.on.pull_site_action, self._pull_site_action)
 
         self.ingress = IngressRequires(self, {
-            "service-hostname": self.app.name,
+            "service-hostname": self._external_hostname,
             "service-name": self.app.name,
             "service-port": 8080
         })
+
+    @property
+    def _external_hostname(self):
+        """Return the external hostname to be passed to ingress via the relation."""
+        # It is recommended to default to `self.app.name` so that the external
+        # hostname will correspond to the deployed application name in the
+        # model, but allow it to be set to something specific via config.
+        return self.config["external-hostname"] or self.app.name
 
     def _on_install(self, _):
         # Download the site


### PR DESCRIPTION
Default to using a hostname that matches the deployed application name in the model, per current guidelines.

This charm will be used as a reference for others, so it's worth updating so others copying it will DTRT.