### PR TITLE
Defer if we have a pebble connection error

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -66,7 +66,7 @@ class HelloKubeconCharm(CharmBase):
             # defer the event, meaning it will be retried the next time any
             # hook is executed. We don't have an explicit handler for
             # `self.on.gosherve_pebble_ready` but this method will be rerun
-            # when that condition is met (because of event.`defer()`), and so
+            # when that condition is met (because of `event.defer()`), and so
             # the `get_container` call will succeed and we'll continue to the
             # subsequent steps.
             event.defer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,8 +54,12 @@ class HelloKubeconCharm(CharmBase):
     def _on_config_changed(self, event):
         """Handle the config-changed event"""
         # Get the gosherve container so we can configure/manipulate it
+        container = self.unit.get_container("gosherve")
+        # Create a new config layer
+        layer = self._gosherve_layer()
         try:
-            container = self.unit.get_container("gosherve")
+            # Get the current config
+            services = container.get_plan().to_dict().get("services", {})
         except ConnectionError:
             # Since this is a config-changed handler and that hook can execute
             # before pebble is ready, we may get a connection error here. Let's
@@ -67,10 +71,6 @@ class HelloKubeconCharm(CharmBase):
             # subsequent steps.
             event.defer()
             return
-        # Create a new config layer
-        layer = self._gosherve_layer()
-        # Get the current config
-        services = container.get_plan().to_dict().get("services", {})
         # Check if there are any changes to services
         if services != layer["services"]:
             # Changes were made, add the new layer


### PR DESCRIPTION
Since the config-changed hook can fire before pebble-ready we should defer, and explain why we're doing so.