### PR TITLE
Handle the pebble-ready event in case it fires after config-changed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -30,6 +30,7 @@ class HelloKubeconCharm(CharmBase):
         super().__init__(*args)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.gosherve_pebble_ready, self._on_config_changed)
         self.framework.observe(self.on.pull_site_action, self._pull_site_action)
 
         self.ingress = IngressRequires(


### PR DESCRIPTION
Ensure we're reacting to the pebble-ready event in case it fires after config-changed. See https://github.com/jnsgruk/hello-kubecon/issues/10 for details.