### PR TITLE
test: adjust the unit tests to include set_can_connect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops >= 1.5.3

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -45,6 +45,8 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm._gosherve_layer(), expected)
 
     def test_on_config_changed(self):
+        # Let the harness know that the container's Pebble is available on the socket
+        self.harness.set_can_connect("gosherve", True)
         plan = self.harness.get_container_pebble_plan("gosherve")
         self.assertEqual(plan.to_dict(), {})
         # Trigger a config-changed hook. Since there was no plan initially, the


### PR DESCRIPTION
In `ops` >= 2.0, one must set `can_connect` in unit tests, or fire the `pebble-ready` event before communicating with the container using Pebble.

This change ensures that this is correctly set for the unit tests.