### PR TITLE
Set SIMULATE_CAN_CONNECT so tests pass on existing versions of ops

### DIFF
--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -6,9 +6,13 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import ops.testing
 from charm import HelloKubeconCharm
 from ops.model import ActiveStatus
 from ops.testing import Harness
+
+
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 class TestCharm(unittest.TestCase):


### PR DESCRIPTION
With https://github.com/jnsgruk/hello-kubecon/commit/d2c05cb936d49278009d29c68d097e1211f09c65, the tests are now breaking on existing versions of ops (but passing on the #873 branch), so add `SIMULATE_CAN_CONNECT` to address that.

See also https://github.com/canonical/operator/pull/873